### PR TITLE
feat: 멤버십 등급 도메인 및 엔티티 생성

### DIFF
--- a/src/main/java/com/example/paymentsystem/domain/membershipTier/controller/MembershipTierController.java
+++ b/src/main/java/com/example/paymentsystem/domain/membershipTier/controller/MembershipTierController.java
@@ -1,0 +1,14 @@
+package com.example.paymentsystem.domain.membershipTier.controller;
+
+import com.example.paymentsystem.domain.membershipTier.service.MembershipTierService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MembershipTierController {
+
+    private final MembershipTierService membershipTierService;
+}

--- a/src/main/java/com/example/paymentsystem/domain/membershipTier/entity/MembershipName.java
+++ b/src/main/java/com/example/paymentsystem/domain/membershipTier/entity/MembershipName.java
@@ -1,0 +1,15 @@
+package com.example.paymentsystem.domain.membershipTier.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MembershipName {
+
+    NORMAL("일반 등급"),
+    VIP("우수 등급"),
+    VVIP("최우수 등급");
+
+    private final String name;
+}

--- a/src/main/java/com/example/paymentsystem/domain/membershipTier/entity/MembershipTier.java
+++ b/src/main/java/com/example/paymentsystem/domain/membershipTier/entity/MembershipTier.java
@@ -1,0 +1,42 @@
+package com.example.paymentsystem.domain.membershipTier.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "membership_tiers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MembershipTier {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Double rewardRate;
+
+    // 승급 기준
+    @Column(nullable = false)
+    private String promotionCriteria;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MembershipName membershipName;
+
+    @Column(nullable = false)
+    private Long minPrice;
+
+    private Long maxPrice;
+
+    public MembershipTier(Double rewardRate, String promotionCriteria, MembershipName membershipName, Long minPrice, Long maxPrice) {
+        this.rewardRate = rewardRate;
+        this.promotionCriteria = promotionCriteria;
+        this.membershipName = membershipName;
+        this.minPrice = minPrice;
+        this.maxPrice = maxPrice;
+    }
+
+
+}

--- a/src/main/java/com/example/paymentsystem/domain/membershipTier/repository/MembershipTierRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/membershipTier/repository/MembershipTierRepository.java
@@ -1,0 +1,7 @@
+package com.example.paymentsystem.domain.membershipTier.repository;
+
+import com.example.paymentsystem.domain.membershipTier.entity.MembershipTier;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MembershipTierRepository extends JpaRepository<MembershipTier, Long> {
+}

--- a/src/main/java/com/example/paymentsystem/domain/membershipTier/service/MembershipTierService.java
+++ b/src/main/java/com/example/paymentsystem/domain/membershipTier/service/MembershipTierService.java
@@ -1,0 +1,12 @@
+package com.example.paymentsystem.domain.membershipTier.service;
+
+import com.example.paymentsystem.domain.membershipTier.repository.MembershipTierRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipTierService {
+
+    private final MembershipTierRepository membershipTierRepository;
+}

--- a/src/main/java/com/example/paymentsystem/domain/point/dto/GetMyPointResponse.java
+++ b/src/main/java/com/example/paymentsystem/domain/point/dto/GetMyPointResponse.java
@@ -1,0 +1,4 @@
+package com.example.paymentsystem.domain.point.dto;
+
+public class GetMyPointResponse {
+}


### PR DESCRIPTION
## 📌 관련 이슈 (선택)
#28 

## 🛠 작업 내용
> 멤버십 등급 정책에 관련된 도메인과 엔티티 생성

## 💻 주요 변경사항
- membershipTier 도메인 추가
- 엔티티 생성

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 네이밍 컨벤션 준수

## 📷 스크린샷 (선택)

