### PR TITLE
[fix] 프론트엔드 회원가입/로그인 백엔드 연동 수정

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -808,7 +808,7 @@ Content-Type: application/json
 
 ## 🔐 인증/인가 (Auth)
 
-### POST /api/signup — 회원가입
+### POST /api/auth/signup — 회원가입
 
 **Description** : 회원가입을 처리합니다.
 
@@ -866,7 +866,7 @@ Content-Type: application/json
 
 ---
 
-### POST /api/login — 로그인
+### POST /api/auth/login — 로그인
 
 **Description** : 로그인을 처리합니다.
 
@@ -921,7 +921,7 @@ Content-Type: application/json
 
 ---
 
-### POST /api/logout — 로그아웃
+### POST /api/auth/logout — 로그아웃
 
 **Description** : 로그아웃을 처리합니다.
 

--- a/src/main/java/com/example/paymentsystem/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/paymentsystem/common/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                                 .requestMatchers(toH2Console()).permitAll()
 
                                 // 템플릿 페이지 렌더링 허용 (html 파일)
-                                .requestMatchers(HttpMethod.GET, "/").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/", "/home").permitAll()
                                 .requestMatchers("/api/auth/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/pages/**").permitAll()

--- a/src/main/java/com/example/paymentsystem/common/init/TestDataInit.java
+++ b/src/main/java/com/example/paymentsystem/common/init/TestDataInit.java
@@ -1,0 +1,40 @@
+package com.example.paymentsystem.common.init;
+
+import com.example.paymentsystem.common.exception.ErrorCode;
+import com.example.paymentsystem.common.exception.ServiceException;
+import com.example.paymentsystem.domain.auth.dto.request.SignUpRequest;
+import com.example.paymentsystem.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TestDataInit implements ApplicationRunner {
+
+    private final AuthService authService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        // 프론트 로그인 페이지에 표시된 테스트 계정
+        String name = "임하은";
+        String email = "admin@test.com";
+        String password = "admin";
+
+        try {
+            authService.signUp(new SignUpRequest(name, email, password));
+            log.info("임시 회원 생성 완료: {}", email);
+        } catch (ServiceException e) {
+            // 이미 가입된 경우 서버 시작이 실패하지 않도록 무시
+            if (ErrorCode.DUPLICATED_EMAIL.getMessage().equals(e.getMessage())) {
+                log.info("임시 회원이 이미 존재합니다: {}", email);
+                return;
+            }
+
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -1,75 +1,268 @@
 # ========================================
 # 클라이언트 API 계약 설정
 # ========================================
-# 수강생들이 이 파일을 수정하여 API 계약을 자유롭게 정의할 수 있습니다.
-# URL, 필드명, 타입 등을 변경하면 클라이언트가 자동으로 적응합니다.
+# 경로·요청 필드는 docs/api-spec.md 및 백엔드 구현을 참고합니다.
 #
-# pathParams 사용법:
-# - URL에 경로 파라미터가 있는 경우 pathParams에 정의합니다
-# - 예시: url: /api/payments/{paymentId}/confirm
-#   pathParams:
-#     - name: paymentId
-#       description: 결제 ID
+# 공통 응답 래퍼: com.example.paymentsystem.common.dto.ApiResponse
+#   - success (boolean)
+#   - data (제네릭, 성공 시 페이로드 / 실패 시 보통 null)
+#   - message (string)
 #
-# 클라이언트에서 사용하는 3가지 방법:
-# 1. 객체로 전달 (이름 매핑): pathParams: { paymentId: 'PAY-123' }
-# 2. 배열로 전달 (순서 매핑): pathParams: ['PAY-123']
-# 3. 단일 값 전달 (첫 번째 파라미터): pathParams: 'PAY-123'
-#
-#   URL의 파라미터 이름을 변경해도 (예: {id})
-#    클라이언트는 방법 2, 3을 사용하면 수정 불필요!
+# pathParams: URL 템플릿 {name} 과 순서·이름 매핑 (api-handler / app-config.js)
 
 api:
   base-url: http://localhost:8080
 
-  # API 엔드포인트 및 계약 정의
   endpoints:
-    # ========================================
-    # 인증 (Authentication)
-    # ========================================
-    login:
-      url:
-      method:
-      description: 사용자 로그인
+    # ---------- 주문 (Order) — api-spec.md ----------
+    create-order:
+      url: /api/orders
+      method: POST
+      description: 주문 생성
       request:
         fields:
-          - name: email
-            type: string
+          - name: orderItems
+            type: array
             required: true
-            example: admin@test.com
-          - name: password
-            type: string
-            required: true
-            example: admin
+            description: "[{ productId, quantity }, ...] — 최소 1개"
+          - name: usedPoint
+            type: number
+            required: false
+            description: 사용 포인트 (미입력 시 0 등 서버 규칙에 따름)
       response:
-        headers:
-          - name: Authorization
-            required: true
-            description: "JWT 토큰 (Bearer {token} 형식)"
         body:
           fields:
             - name: success
               type: boolean
               required: true
-              description: 로그인 성공 여부
-            - name: email
+            - name: data
+              type: object
+              required: true
+              description: "{ orderId, orderNumber, totalPrice, usedPoint, paymentPrice, orderStatus, orderedCreatedAt }"
+            - name: message
               type: string
-              required: false
-              description: 로그인한 사용자 이메일
+              required: true
 
-    register:
-      url:
-      method:
-      description: 회원가입
+    list-orders:
+      url: /api/orders
+      method: GET
+      description: 내 주문 내역 조회
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ orders[], pagination: { currentPage, size, totalCount, totalPages } }"
+            - name: message
+              type: string
+              required: true
+
+    get-order:
+      url: /api/orders/{orderId}
+      method: GET
+      description: 주문 상세 조회
+      pathParams:
+        - name: orderId
+          description: 주문 ID
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ orderId, orderNumber, totalAmount, usedPoint, paymentPrice, orderStatus, orderedCreatedAt, payment?, orderItems[] }"
+            - name: message
+              type: string
+              required: true
+
+    confirm-order:
+      url: /api/orders/{orderId}/confirm
+      method: POST
+      description: 주문 확정(상태 변경)
+      pathParams:
+        - name: orderId
+          description: 주문 ID
       request:
         fields:
-          - name: name
+          - name: status
             type: string
             required: true
+            description: 예) ORDER_CONFIRMED
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ orderId, orderStatus, confirmedAt }"
+            - name: message
+              type: string
+              required: true
+
+    # ---------- 환불 (Refund) ----------
+    create-refund:
+      url: /api/payments/{paymentId}/refunds
+      method: POST
+      description: 환불 요청
+      pathParams:
+        - name: paymentId
+          description: 결제 ID (PortOne payment id 등)
+      request:
+        fields:
+          - name: refundReason
+            type: string
+            required: true
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ id, paymentId, refundPrice, refundReason, refundStatus, refundCreatedAt }"
+            - name: message
+              type: string
+              required: true
+
+    list-order-refunds:
+      url: /api/orders/{orderId}/refunds
+      method: GET
+      description: 특정 주문 환불 내역 조회
+      pathParams:
+        - name: orderId
+          description: 주문 ID
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: 단일 환불 레코드 객체 (명세 예시 기준)
+            - name: message
+              type: string
+              required: true
+
+    list-my-refunds:
+      url: /api/refunds/me
+      method: GET
+      description: 내 환불 내역 전체 조회
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ refund[], pagination }"
+            - name: message
+              type: string
+              required: true
+
+    # ---------- 포인트 ----------
+    get-my-points:
+      url: /api/points/me
+      method: GET
+      description: 내 포인트 조회
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ userId, myPoint }"
+            - name: message
+              type: string
+              required: true
+
+    list-point-history:
+      url: /api/points/me/history
+      method: GET
+      description: 포인트 거래 내역 조회
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: array
+              required: true
+              description: "[{ id, orderId, point, type, pointCreatedAt, pointExpiredAt }]"
+            - name: message
+              type: string
+              required: true
+
+    # ---------- 멤버십 ----------
+    get-my-membership:
+      url: /api/membership/me
+      method: GET
+      description: 나의 멤버십 등급 조회
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ id, userId, gradeNow, totalPrice, gradeUpdatedAt }"
+            - name: message
+              type: string
+              required: true
+
+    list-membership-tiers:
+      url: /api/membership/tiers
+      method: GET
+      description: 멤버십 등급별 정책 조회
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: array
+              required: true
+              description: "[{ id, rewardRate, promotionCriteria, gradeName, minPrice, maxPrice }]"
+            - name: message
+              type: string
+              required: true
+
+    # ---------- 인증 ----------
+    register:
+      url: /api/auth/signup
+      method: POST
+      description: 회원가입 (명세 POST /api/auth/signup)
+      request:
+        fields:
           - name: email
             type: string
             required: true
           - name: password
+            type: string
+            required: true
+          - name: name
             type: string
             required: true
           - name: phone
@@ -81,411 +274,382 @@ api:
             - name: success
               type: boolean
               required: true
-              description: 회원가입 성공 여부
+            - name: data
+              type: object
+              required: true
+              description: "{ id, email, name, phone }"
             - name: message
               type: string
-              required: false
-              description: 에러 메시지 (실패 시)
+              required: true
 
-    get-current-user:
-      url:
-      method:
-      description: 현재 로그인한 사용자 정보 조회
-      response:
-        body:
-          fields:
-            - name: customerUid
-              type: string
-              required: true
-              description: PortOne 고객 고유 식별자 (서버에서 customerUid로 관리)
-              usage: PortOne payment window customer.customerId
-            - name: email
-              type: string
-              required: true
-              description: 사용자 이메일
-              usage: PortOne payment window customer.email
-            - name: name
-              type: string
-              required: true
-              description: 사용자 이름
-              usage: PortOne payment window customer.fullName
-            - name: phone
-              type: string
-              required: true
-              description: 사용자 전화번호 (KG 이니시스 필수)
-              usage: PortOne payment window customer.phoneNumber
-            - name: pointBalance
-              type: number
-              required: true
-              description: 현재 포인트 잔액
-
-    # ========================================
-    # 상품 & 주문 (Product & Order)
-    # ========================================
-    list-products:
-      url:
-      method:
-      description: 상품 목록 조회
-      response:
-        body:
-          type: array
-          items:
-            - name: id
-              type: string
-              required: true
-              description: 상품 ID
-            - name: name
-              type: string
-              required: true
-              description: 상품명
-            - name: price
-              type: number
-              required: true
-              description: 가격
-            - name: stock
-              type: number
-              required: true
-              description: 재고 수량
-
-    create-order:
-      url:
-      method:
-      description: 주문 생성 (총 금액은 서버에서 계산)
+    login:
+      url: /api/auth/login
+      method: POST
+      description: 로그인
       request:
         fields:
-          - name: items
-            type: array
-            required: true
-            description: "주문 아이템 배열 [{ productId, quantity }] - productId로 상품 조회 후 서버에서 가격 계산"
-      response:
-        body:
-          fields:
-            - name: orderId
-              type: string
-              required: true
-              description: 생성된 주문 ID
-              usage: 주문 페이지 리다이렉트에 사용
-            - name: totalAmount
-              type: number
-              required: false
-              description: 서버에서 계산된 총 금액
-            - name: orderNumber
-              type: string
-              required: false
-              description: 생성된 주문 번호
-
-    list-orders:
-      url:
-      method:
-      description: 주문 목록 조회 (현재 로그인한 사용자의 주문)
-      response:
-        body:
-          type: array
-          items:
-            - name: orderNumber
-              type: string
-              required: true
-              description: 주문 번호 (사용자에게 보이는 주문 번호)
-            - name: orderId
-              type: string
-              required: true
-              description: 주문 ID (시스템 고유 식별자)
-            - name: totalAmount
-              type: number
-              required: true
-              description: 주문 금액 (포인트 차감 전)
-            - name: usedPoints
-              type: number
-              required: false
-              description: 사용한 포인트
-            - name: finalAmount
-              type: number
-              required: false
-              description: 최종 결제 금액 (포인트 차감 후)
-            - name: earnedPoints
-              type: number
-              required: false
-              description: 적립된 포인트
-            - name: currency
-              type: string
-              required: true
-              description: 통화
-            - name: status
-              type: string
-              required: true
-              description: 주문 상태 (PENDING, PAID, CANCELLED 등)
-            - name: createdAt
-              type: string
-              required: false
-              description: 주문 생성 시간
-
-    # ========================================
-    # 결제 (Payment)
-    # ========================================
-    create-payment:
-      url:
-      method:
-      description: 결제 시작 요청 (DB에 PENDING 상태로 등록, PortOne SDK 호출 전에 먼저 호출)
-      request:
-        fields:
-          - name: orderId
+          - name: email
             type: string
             required: true
-            description: 주문 ID (서버에서 주문 정보 조회)
-          - name: totalAmount
-            type: number
+          - name: password
+            type: string
             required: true
-            description: 결제 금액
-          - name: pointsToUse
-            type: number
-            required: false
-            description: "사용할 포인트 (선택 사항, 0 이상)"
       response:
         body:
           fields:
             - name: success
               type: boolean
               required: true
-              description: 생성 성공 여부
-            - name: paymentId
+            - name: data
+              type: object
+              required: true
+              description: "{ accessToken, refreshToken, grantType }"
+            - name: message
               type: string
               required: true
-              description: 생성된 결제 ID (PortOne SDK에 전달할 ID)
-            - name: status
-              type: string
-              required: false
-              description: 결제 상태 (PENDING)
 
-    confirm-payment:
-      url:
-      method:
-      description: 결제 확정 (PortOne 결제 검증 및 주문 상태 업데이트)
-      pathParams:
-        - name:
-          description: 결제 ID
-      response:
-        body:
-          fields:
-            - name: success
-              type: boolean
-              required: true
-              description: 확정 성공 여부
-            - name: orderId
-              type: string
-              required: false
-              description: 주문 ID
-            - name: status
-              type: string
-              required: false
-              description: 변경된 주문 상태
-
-    cancel-payment:
-      url:
-      method:
-      description: 결제 취소/환불 (PortOne 결제 취소 및 주문 상태 업데이트)
-      pathParams:
-        - name:
-          description: 결제 ID
+    logout:
+      url: /api/auth/logout
+      method: POST
+      description: 로그아웃
       request:
         fields:
+          - name: refreshToken
+            type: string
+            required: true
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: false
+              description: "성공 시 null 일 수 있음 (ApiResponse)"
+            - name: message
+              type: string
+              required: true
+
+    # ---------- 상품 ----------
+    list-products:
+      url: /api/products
+      method: GET
+      description: 상품 목록 조회 (현재 백엔드는 data에 상품 배열만 둘 수 있음)
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: array
+              required: true
+              description: "[{ id, name, price, stock, status, category }] 또는 명세형 { products[], pagination } 을 data 안에 두는 경우 object"
+            - name: message
+              type: string
+              required: true
+
+    get-product:
+      url: /api/products/{productId}
+      method: GET
+      description: 상품 단건 조회
+      pathParams:
+        - name: productId
+          description: 상품 ID
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "단건 상품 DTO (필드명은 ProductDetailResponse 등 백엔드에 따름)"
+            - name: message
+              type: string
+              required: true
+
+    # ---------- 결제 / 웹훅 / PortOne (명세) ----------
+    # 웹훅·PortOne 직접 호출 응답은 ApiResponse 가 아님 (200 빈 본문 또는 PortOne 스키마)
+    payments-webhook:
+      url: /api/payments/webhook
+      method: POST
+      description: PortOne 웹훅 (결제 이벤트 수신). 응답 200 OK, 본문 없음
+      request:
+        fields:
+          - name: type
+            type: string
+            required: true
+            description: 예) Transaction.Cancelled
+          - name: timestamp
+            type: string
+            required: true
+          - name: data
+            type: object
+            required: true
+            description: "{ storeId, paymentId, transactionId 등 }"
+
+    portone-get-payment:
+      url: https://api.portone.io/payments/{paymentId}
+      method: GET
+      description: PortOne 결제 검증 (ApiResponse 아님, PortOne API 응답 본문)
+      pathParams:
+        - name: paymentId
+          description: 결제 건 ID
+
+    portone-cancel-payment:
+      url: https://api.portone.io/payments/{paymentId}/cancel
+      method: POST
+      description: PortOne 결제 취소 (ApiResponse 아님, PortOne API 응답 본문)
+      pathParams:
+        - name: paymentId
+          description: 결제 건 ID
+      request:
+        fields:
+          - name: amount
+            type: number
+            required: true
           - name: reason
             type: string
+            required: true
+          - name: skipWebhook
+            type: boolean
             required: false
-            description: 취소 사유
+
+    # ---------- 데모·연동용 (명세 문서에 없음, 기존 정적 페이지 호환) ----------
+    get-current-user:
+      url: /api/users/me
+      method: GET
+      description: "명세 외: 현재 사용자(데모). 실제 경로는 백엔드에 맞게 조정"
       response:
         body:
           fields:
             - name: success
               type: boolean
               required: true
-              description: 취소 성공 여부
-            - name: orderId
-              type: string
+            - name: data
+              type: object
               required: false
-              description: 주문 ID
-            - name: status
+              description: "{ customerUid?, email?, name?, phone?, pointBalance? }"
+            - name: message
               type: string
-              required: false
-              description: 변경된 주문 상태
+              required: true
 
-    # ========================================
-    # 구독 & 빌링키 (Subscription & Billing Key)
-    # ========================================
-    list-plans:
-      url:
-      method:
-      description: 구독 플랜 목록 조회
+    create-payment:
+      url: /api/orders/{orderId}/payments
+      method: POST
+      description: "명세 외: 주문 결제 시도(PaymentController). pathParams.orderId 필수. 본문은 서버 DTO에 맞게 payment_price(또는 팀 표준 필드명)"
+      pathParams:
+        - name: orderId
+          description: 주문 ID (URL 경로)
+      request:
+        fields:
+          - name: payment_price
+            type: number
+            required: true
+            description: 결제 금액 (PaymentTryRequest)
       response:
         body:
-          type: array
-          items:
-            - name: planId
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: false
+              description: 결제/주문 처리 결과 페이로드 (구현에 따름)
+            - name: message
               type: string
               required: true
-              description: "플랜 ID (자유 형식: PLAN-PRO, PRO, 1, etc.)"
-            - name: name
+
+    confirm-payment:
+      url: /api/payments/{paymentId}/confirm
+      method: POST
+      description: "명세 외: 결제 확정(검증)용 플레이스홀더 — 구현 시 URL 조정"
+      pathParams:
+        - name: paymentId
+          description: 결제 ID
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: false
+              description: "{ orderId?, status? } 등 구현에 따름"
+            - name: message
               type: string
               required: true
-              description: 플랜 이름
-            - name: amount
-              type: number
+
+    cancel-payment:
+      url: https://api.portone.io/payments/{paymentId}/cancel
+      method: POST
+      description: "PortOne 결제 취소 API (명세 POST .../cancel 과 동일 호스트)"
+      pathParams:
+        - name: paymentId
+          description: 결제 ID
+      request:
+        fields:
+          - name: amount
+            type: number
+            required: true
+          - name: reason
+            type: string
+            required: true
+          - name: skipWebhook
+            type: boolean
+            required: false
+
+    list-plans:
+      url: /api/subscription-plans
+      method: GET
+      description: "명세 외: 구독 플랜 목록(데모)"
+      response:
+        body:
+          fields:
+            - name: success
+              type: boolean
               required: true
-              description: 플랜 금액
-            - name: billingCycle
+            - name: data
+              type: array
+              required: true
+              description: "[{ planId, name, amount, billingCycle }, ...]"
+            - name: message
               type: string
               required: true
-              description: 결제 주기 (MONTHLY, QUARTERLY, ANNUAL)
 
     create-subscription:
-      url:
-      method:
-      description: 구독 생성 (빌링키 저장 + 구독 생성을 하나의 트랜잭션으로 처리)
+      url: /api/subscriptions
+      method: POST
+      description: "명세 외: 구독 생성(데모)"
       request:
         fields:
           - name: customerUid
             type: string
             required: true
-            description: PortOne 고객 고유 식별자
           - name: planId
             type: string
             required: true
-            description: 구독할 플랜 ID
           - name: billingKey
             type: string
             required: true
-            description: PortOne에서 발급받은 빌링키 (서버에서 결제수단으로 저장)
           - name: amount
             type: number
             required: true
-            description: 구독 금액
       response:
         body:
           fields:
-            - name: subscriptionId
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ subscriptionId, ... }"
+            - name: message
               type: string
               required: true
-              description: 생성된 구독 ID
-              usage: 구독 관리 페이지 리다이렉트에 사용
 
     get-subscription:
-      url:
-      method:
-      description: 구독 조회
+      url: /api/subscriptions/{subscriptionId}
+      method: GET
+      description: "명세 외: 구독 단건 조회(데모)"
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       response:
         body:
           fields:
-            - name: subscriptionId
+            - name: success
+              type: boolean
+              required: true
+            - name: data
+              type: object
+              required: true
+              description: "{ subscriptionId, customerUid, planId, paymentMethodId?, status, amount, currentPeriodEnd }"
+            - name: message
               type: string
               required: true
-            - name: customerUid
-              type: string
-              required: true
-              description: PortOne 고객 고유 식별자
-            - name: planId
-              type: string
-              required: true
-            - name: paymentMethodId
-              type: string
-              required: false
-              description: 결제 수단 ID (결제수단 테이블 참조)
-            - name: status
-              type: string
-              required: true
-              description: "구독 상태 (ACTIVE: 활성, CANCELLED: 해지, SUSPENDED: 미납, EXPIRED: 기간 종료)"
-            - name: amount
-              type: number
-              required: true
-            - name: currentPeriodEnd
-              type: string
-              required: true
-              description: "현재 이용 기간 종료일 (ISO 8601 형식, 예: 2026-03-01T23:59:59)"
 
     update-subscription:
-      url:
-      method:
-      description: 구독 상태 업데이트 (구독 해지)
+      url: /api/subscriptions/{subscriptionId}
+      method: PATCH
+      description: "명세 외: 구독 상태 변경(데모)"
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       request:
         fields:
           - name: action
             type: string
             required: true
-            description: "액션 타입: 'cancel' (구독 해지) 등"
           - name: reason
             type: string
             required: false
-            description: 해지 사유
       response:
         body:
           fields:
             - name: success
               type: boolean
               required: true
-              description: 성공 여부
-            - name: subscriptionId
-              type: string
+            - name: data
+              type: object
               required: false
-            - name: status
+              description: "{ subscriptionId?, status? }"
+            - name: message
               type: string
-              required: false
-              description: 변경된 구독 상태
+              required: true
 
     create-billing:
-      url:
-      method:
-      description: 즉시 결제 (현재 주기 청구 실행)
+      url: /api/subscriptions/{subscriptionId}/billings
+      method: POST
+      description: "명세 외: 구독 청구(데모)"
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       request:
         fields:
           - name: periodStart
             type: string
             required: true
-            description: "청구 기간 시작일 (ISO 8601 형식, 예: 2026-02-01T00:00:00)"
           - name: periodEnd
             type: string
             required: true
-            description: "청구 기간 종료일 (ISO 8601 형식, 예: 2026-02-28T23:59:59)"
       response:
         body:
           fields:
             - name: success
               type: boolean
               required: true
-            - name: billingId
+            - name: data
+              type: object
+              required: true
+              description: "{ billingId, paymentId?, amount, status }"
+            - name: message
               type: string
               required: true
-              description: 생성된 구독 청구 ID
-            - name: paymentId
-              type: string
-              required: false
-              description: 빌링키 결제 시 사용된 결제 건 ID (PortOne)
-            - name: amount
-              type: number
-              required: true
-              description: 청구 금액
-            - name: status
-              type: string
-              required: true
-              description: "청구 상태 (COMPLETED: 결제 완료, FAILED: 실패)"
 
     list-billing-history:
-      url:
-      method:
-      description: 청구 내역 조회
+      url: /api/subscriptions/{subscriptionId}/billings
+      method: GET
+      description: "명세 외: 청구 내역(데모)"
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       response:
         body:
           fields:
-            - name: billings
-              type: array
+            - name: success
+              type: boolean
               required: true
-              description: "청구 내역 배열. 각 요소는 { billingId: string (필수), periodStart: string (필수, ISO 8601), periodEnd: string (필수, ISO 8601), amount: number (필수), status: string (필수, COMPLETED/FAILED/PENDING), paymentId: string (선택), attemptDate: string (선택, ISO 8601), failureMessage: string (선택) } 형태"
+            - name: data
+              type: object
+              required: true
+              description: "{ billings: [] }"
+            - name: message
+              type: string
+              required: true

--- a/src/main/resources/static/js/app-config.js
+++ b/src/main/resources/static/js/app-config.js
@@ -110,8 +110,9 @@ async function buildApiUrl(endpointKey, params = {}) {
         throw new Error(`엔드포인트 '${endpointKey}'를 설정에서 찾을 수 없습니다`);
     }
 
-    // URL 가져오기
+    // URL 가져오기 (절대 URL이면 api.base-url 를 붙이지 않음)
     let url = endpointContract.url;
+    const isAbsoluteUrl = /^https?:\/\//i.test(url);
 
     // URL에서 경로 파라미터 이름 추출 (예: /api/payments/{paymentId} → ['paymentId'])
     const urlParamNames = (url.match(/\{([^}]+)\}/g) || [])
@@ -119,7 +120,7 @@ async function buildApiUrl(endpointKey, params = {}) {
 
     // 파라미터가 없으면 바로 반환
     if (urlParamNames.length === 0) {
-        return config.api.baseUrl + url;
+        return isAbsoluteUrl ? url : config.api.baseUrl + url;
     }
 
     // params를 정규화: string이나 array를 object로 변환
@@ -163,7 +164,7 @@ async function buildApiUrl(endpointKey, params = {}) {
         );
     }
 
-    return config.api.baseUrl + url;
+    return isAbsoluteUrl ? url : config.api.baseUrl + url;
 }
 
 // 페이지 로드 시 자동으로 설정 로드

--- a/src/main/resources/static/js/cookie-util.js
+++ b/src/main/resources/static/js/cookie-util.js
@@ -51,6 +51,14 @@ function saveToken(token) {
 }
 
 /**
+ * 리프레시 토큰 저장 (쿠키) — 로그아웃 등에서 서버에 전달
+ * @param {string} token - 리프레시 JWT
+ */
+function saveRefreshToken(token) {
+    setCookie('jwt_refresh_token', token, 14);
+}
+
+/**
  * JWT 토큰 조회 (쿠키)
  * @returns {string|null} JWT 토큰 또는 null
  */
@@ -59,10 +67,19 @@ function getToken() {
 }
 
 /**
+ * 리프레시 토큰 조회 (쿠키)
+ * @returns {string|null}
+ */
+function getRefreshToken() {
+    return getCookie('jwt_refresh_token');
+}
+
+/**
  * JWT 토큰 삭제 (쿠키)
  */
 function removeToken() {
     deleteCookie('jwt_token');
+    deleteCookie('jwt_refresh_token');
 }
 
 /**

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -80,32 +80,32 @@
             errorMessage.style.display = 'none';
 
             try {
-                // returnHeaders: true 옵션으로 헤더도 받아오기
                 const result = await makeApiRequest('login', {
                     body: {
                         email: email,
                         password: password
-                    },
-                    returnHeaders: true
+                    }
                 });
 
                 // YML 스키마 기반 자동 검증
-                if (!validateApiResponse('login', result.data, result.headers)) {
+                if (!validateApiResponse('login', result)) {
                     errorText.textContent = 'API 응답 형식이 올바르지 않습니다.';
                     errorMessage.style.display = 'block';
                     return;
                 }
 
-                if (result.data.success) {
-                    // Authorization 헤더에서 토큰 추출
-                    const authHeader = result.headers['authorization'];
-                    if (authHeader && authHeader.startsWith('Bearer ')) {
-                        const token = authHeader.substring(7);  // "Bearer " 제거
+                if (result.success) {
+                    const payload = result.data;
+                    const accessToken =
+                        payload && typeof payload === 'object' ? payload.accessToken : null;
+                    const refreshToken =
+                        payload && typeof payload === 'object' ? payload.refreshToken : null;
 
-                        // JWT 토큰을 쿠키에 저장
-                        saveToken(token);
-
-                        // 홈으로 이동
+                    if (accessToken) {
+                        saveToken(accessToken);
+                        if (refreshToken) {
+                            saveRefreshToken(refreshToken);
+                        }
                         window.location.href = '/home';
                     } else {
                         errorText.textContent = '토큰을 받을 수 없습니다.';
@@ -113,7 +113,7 @@
                     }
                 } else {
                     // 로그인 실패
-                    errorText.textContent = result.data.message || '이메일 또는 비밀번호가 올바르지 않습니다.';
+                    errorText.textContent = result.message || '이메일 또는 비밀번호가 올바르지 않습니다.';
                     errorMessage.style.display = 'block';
                 }
             } catch (error) {


### PR DESCRIPTION
## 📌 관련 이슈 (선택)
#41 

## 🛠 작업 내용
> 프론트엔드측에서 회원가입/로그인 API를 호출하는 코드를 수정하고, 테스트데이터로 임시회원 (email: admin@test.com / pw: admin)을 자동생성하도록 구현함.

## 💻 주요 변경사항
- 프론트 로그인/회원가입 요청 정상작동
- TestDataInit.java파일로 앱 구동시 자동으로 임시회원 생성
- SecurityConfig에 대시보드 화면(/home) 허용 (permitAll)


