### PR TITLE
feat: 고객정보 조회 기능 추가 및 API명세서에 맞게 API수정

### DIFF
--- a/src/main/java/com/example/paymentsystem/common/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/paymentsystem/common/config/JwtAuthenticationFilter.java
@@ -7,12 +7,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -27,13 +29,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 토큰이 유효하면 인증 객체를 생성하여 SecurityContext에 저장
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            // 이메일(Subject) 추출
+            // id 추출
             Long id = jwtTokenProvider.getUserId(token);
 
             // 유저 인증 객체 생성
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(id, null, Collections.emptyList());
-
+                    new UsernamePasswordAuthenticationToken(id, null, List.of(new SimpleGrantedAuthority("USER")));
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/example/paymentsystem/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/paymentsystem/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.paymentsystem.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -17,6 +18,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static org.springframework.boot.security.autoconfigure.web.servlet.PathRequest.toH2Console;
 import static org.springframework.boot.security.autoconfigure.web.servlet.PathRequest.toStaticResources;
@@ -24,9 +26,10 @@ import static org.springframework.boot.security.autoconfigure.web.servlet.PathRe
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-
+    private final JwtTokenProvider jwtTokenProvider;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -57,8 +60,10 @@ public class SecurityConfig {
                                 .requestMatchers("/api/public/**").permitAll()
 
                         // 나머지 전부 인증 필요
-                        // .anyRequest().authenticated()
-                )
+                        // .anyRequest().authenticated
+
+                ).addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
         ;
 
 

--- a/src/main/java/com/example/paymentsystem/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/paymentsystem/common/exception/ErrorCode.java
@@ -10,8 +10,10 @@ public enum ErrorCode {
 
     // auth
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일 입니다."),
+    DUPLICATED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 가입된 전화번호 입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다. 다시 인증을 시도해 주세요."),
     // order
     INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "보유 포인트가 부족합니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "주문할 상품을 찾을 수 없습니다."),

--- a/src/main/java/com/example/paymentsystem/common/init/TestDataInit.java
+++ b/src/main/java/com/example/paymentsystem/common/init/TestDataInit.java
@@ -23,9 +23,10 @@ public class TestDataInit implements ApplicationRunner {
         String name = "임하은";
         String email = "admin@test.com";
         String password = "admin";
+        String phoneNumber = "01011113333";
 
         try {
-            authService.signUp(new SignUpRequest(name, email, password));
+            authService.signUp(new SignUpRequest(name, email, password, phoneNumber));
             log.info("임시 회원 생성 완료: {}", email);
         } catch (ServiceException e) {
             // 이미 가입된 경우 서버 시작이 실패하지 않도록 무시

--- a/src/main/java/com/example/paymentsystem/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/controller/AuthController.java
@@ -2,16 +2,21 @@ package com.example.paymentsystem.domain.auth.controller;
 
 import com.example.paymentsystem.common.config.JwtTokenProvider;
 import com.example.paymentsystem.common.dto.ApiResponse;
+import com.example.paymentsystem.common.exception.ErrorCode;
+import com.example.paymentsystem.common.exception.ServiceException;
 import com.example.paymentsystem.domain.auth.dto.request.LogInRequest;
 import com.example.paymentsystem.domain.auth.dto.request.SignUpRequest;
 import com.example.paymentsystem.domain.auth.dto.response.LogOutResponse;
 import com.example.paymentsystem.domain.auth.dto.response.SignUpResponse;
 import com.example.paymentsystem.domain.auth.dto.response.TokenResponse;
+import com.example.paymentsystem.domain.auth.dto.response.UserInfoResponse;
+import com.example.paymentsystem.domain.auth.entity.User;
 import com.example.paymentsystem.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -50,5 +55,18 @@ public class AuthController {
             response = new LogOutResponse(false, "로그아웃 실패");
         }
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(@AuthenticationPrincipal Long userId) {
+        if (userId == null) {
+            throw new ServiceException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 2. 서비스 레이어 호출 (ID를 넘겨서 DB 조회 및 DTO 변환)
+        UserInfoResponse response = authService.userInfo(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+
     }
 }

--- a/src/main/java/com/example/paymentsystem/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/dto/request/SignUpRequest.java
@@ -2,11 +2,20 @@ package com.example.paymentsystem.domain.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
-        @NotBlank String name,
-        @Email @NotBlank String email,
-        @NotBlank @Size(min = 8) String password
+        @NotBlank(message = "이름은 필수 입력 값입니다.") String name,
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.") String email,
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.") String password,
+        @NotBlank(message = "전화번호는 필수 입력 값입니다.")
+        @Pattern(
+                regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$",
+                message = "하이픈(-)을 제외한 올바른 전화번호 형식이어야 합니다."
+        )
+                String phoneNumber
 ) {
 }

--- a/src/main/java/com/example/paymentsystem/domain/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/dto/response/SignUpResponse.java
@@ -5,9 +5,10 @@ import com.example.paymentsystem.domain.auth.entity.User;
 public record SignUpResponse(
         Long id,
         String email,
-        String name
+        String name,
+        String phoneNumber
 ) {
     public static SignUpResponse from (User user) {
-        return new SignUpResponse(user.getId(), user.getEmail(), user.getName());
+        return new SignUpResponse(user.getId(), user.getEmail(), user.getName(), user.getPhoneNumber());
     }
 }

--- a/src/main/java/com/example/paymentsystem/domain/auth/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/dto/response/UserInfoResponse.java
@@ -1,0 +1,14 @@
+package com.example.paymentsystem.domain.auth.dto.response;
+
+import com.example.paymentsystem.domain.auth.entity.User;
+
+public record UserInfoResponse(
+        String name,
+        String email,
+        String phoneNumber,
+        Long point
+) {
+    public static UserInfoResponse from (User user) {
+        return new UserInfoResponse(user.getEmail(), user.getName(), user.getPhoneNumber(), user.getPoint());
+    }
+}

--- a/src/main/java/com/example/paymentsystem/domain/auth/entity/User.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/entity/User.java
@@ -28,27 +28,30 @@ public class User extends BaseEntity {
     @Pattern(regexp = "^[A-Za-z0-9+_.-]+@(.+)$", message = "이메일 형식을 다시 확인해주세요.")
     private String email;
 
+    @Column(nullable = false, unique = true, length = 11)
+    @Pattern(
+            regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$",
+            message = "올바른 전화번호 형식(하이픈 제외 10~11자리 숫자)이 아닙니다."
+    )
+    private String phoneNumber;
+
     @Column(nullable = false)
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-    @Pattern(
-            regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\\S+$).{8,}$",
-            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해야 합니다."
-    )
     private String password;
 
-    private String refreshToken;
-
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
     // 임시 추가
     private Long point;
 
     @Builder
-    public User(String name, String email, String password, Long point, Long membership) {
+    public User(String name, String email, String password, String phoneNumber, UserRole role) {
         this.name = name;
         this.email = email;
         this.password = password;
-    }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
+        this.phoneNumber = phoneNumber;
+        this.role = (role != null) ? role : UserRole.USER;
+        this.point = 0L;
     }
 }

--- a/src/main/java/com/example/paymentsystem/domain/auth/entity/UserRole.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/entity/UserRole.java
@@ -1,0 +1,5 @@
+package com.example.paymentsystem.domain.auth.entity;
+
+public enum UserRole {
+    USER, ADMIN
+}

--- a/src/main/java/com/example/paymentsystem/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/example/paymentsystem/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.example.paymentsystem.domain.auth.dto.request.LogInRequest;
 import com.example.paymentsystem.domain.auth.dto.request.SignUpRequest;
 import com.example.paymentsystem.domain.auth.dto.response.SignUpResponse;
 import com.example.paymentsystem.domain.auth.dto.response.TokenResponse;
+import com.example.paymentsystem.domain.auth.dto.response.UserInfoResponse;
 import com.example.paymentsystem.domain.auth.entity.User;
 import com.example.paymentsystem.domain.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +30,15 @@ public class AuthService {
         if(userRepository.existsByEmail(request.email())) {
             throw new ServiceException(ErrorCode.DUPLICATED_EMAIL,ErrorCode.DUPLICATED_EMAIL.getMessage());
         }
-
+        //전화번호 중복 검사
+        if (userRepository.existsByPhoneNumber(request.phoneNumber())) {
+            throw new ServiceException(ErrorCode.DUPLICATED_PHONE_NUMBER);
+        }
         User user = User.builder()
                 .name(request.name())
                 .email(request.email())
-                .password(passwordEncoder.encode(request.password())) // 암호화 적용
+                .password(passwordEncoder.encode(request.password()))
+                .phoneNumber(request.phoneNumber())// 암호화 적용
                 .build();
 
         User savedUser = userRepository.save(user);
@@ -55,4 +60,11 @@ public class AuthService {
         return new TokenResponse(accessToken, "Bearer");
     }
     //유저 조회로직
+    @Transactional
+    public UserInfoResponse userInfo(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+
+        return UserInfoResponse.from(user);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (선택)
#46 

## 🛠 작업 내용
> 어떤 작업을 했는지 간단히 설명

고객정보 조회 기능 추가
API 명세서에 맞게 기타로직 수정

## 💻 주요 변경사항
- 회원가입 시 핸드폰번호를 받도록 수정
- 회원가입 응답 바디에 핸드폰번호를 보여주도록 수정
- 회원가입 시 point는 0, 역할은 USER가 되도록 수정

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 네이밍 컨벤션 준수

## 📷 스크린샷 (선택)
> API 테스트 결과, 변경된 화면 등 첨부
