### PR TITLE
[feat] 포인트 주문 목록/모달 렌더링 및 PortOne 결제 연동 개선

### DIFF
--- a/src/main/java/com/example/paymentsystem/common/init/TestDataInit.java
+++ b/src/main/java/com/example/paymentsystem/common/init/TestDataInit.java
@@ -56,7 +56,8 @@ public class TestDataInit implements ApplicationRunner {
                             200L,
                             "훈련에 딱 맞는 한입 사이즈 치킨맛 간식",
                             ProductStatus.FOR_SALE,
-                            "강아지 간식"
+                            "강아지 간식",
+                            ""
                     ),
                     new Product(
                             2500L,
@@ -64,7 +65,8 @@ public class TestDataInit implements ApplicationRunner {
                             120L,
                             "구강 케어에 도움을 주는 연어 향 덴탈 스틱",
                             ProductStatus.FOR_SALE,
-                            "강아지 간식"
+                            "강아지 간식",
+                            ""
                     ),
                     new Product(
                             1800L,
@@ -72,7 +74,8 @@ public class TestDataInit implements ApplicationRunner {
                             150L,
                             "소고기 풍미의 바삭한 비스킷",
                             ProductStatus.FOR_SALE,
-                            "강아지 간식"
+                            "강아지 간식",
+                            ""
                     ),
                     new Product(
                             3200L,
@@ -80,7 +83,8 @@ public class TestDataInit implements ApplicationRunner {
                             80L,
                             "고구마로 만든 크런치 쿠키(기호성 좋은 간식)",
                             ProductStatus.FOR_SALE,
-                            "강아지 간식"
+                            "강아지 간식",
+                            ""
                     ),
                     new Product(
                             4100L,
@@ -88,7 +92,8 @@ public class TestDataInit implements ApplicationRunner {
                             70L,
                             "야채와 닭가슴살 베이스의 상쾌한 리프레시 간식",
                             ProductStatus.FOR_SALE,
-                            "강아지 간식"
+                            "강아지 간식",
+                            ""
                     ),
                     new Product(
                             5000L,
@@ -96,7 +101,8 @@ public class TestDataInit implements ApplicationRunner {
                             60L,
                             "오리 저키 프리미엄, 쫄깃한 식감의 고급 간식",
                             ProductStatus.FOR_SALE,
-                            "강아지 간식"
+                            "강아지 간식",
+                            ""
                     )
             );
 

--- a/src/main/java/com/example/paymentsystem/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/paymentsystem/domain/payment/entity/Payment.java
@@ -28,7 +28,6 @@ public class Payment extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
     private Long paymentPrice;
-    private LocalDateTime createdAt;
     private LocalDateTime refund_created_at;
 
     public Payment(Order order, String paymentId, PaymentStatus paymentStatus, Long paymentPrice) {

--- a/src/main/resources/static/js/portone-sdk.js
+++ b/src/main/resources/static/js/portone-sdk.js
@@ -39,9 +39,10 @@ async function openPortOnePayment(paymentData) {
         // 1단계: 서버에 결제 시작 요청 (PENDING 상태로 DB 저장)
         console.log('1단계: 서버에 결제 시작 요청...');
         const createPaymentResult = await makeApiRequest('create-payment', {
+            pathParams: { orderId: paymentData.orderId },
             body: {
-                orderId: paymentData.orderId,
-                totalAmount: paymentData.totalAmount
+                // 백엔드 DTO: PaymentTryRequest.payment_price
+                payment_price: paymentData.backendPaymentPrice ?? paymentData.totalAmount
             }
         });
 
@@ -54,9 +55,47 @@ async function openPortOnePayment(paymentData) {
             throw new Error('결제 시작 요청 실패');
         }
 
-        // 서버에서 생성한 paymentId 사용
-        const serverPaymentId = createPaymentResult.paymentId;
-        console.log('서버에서 생성한 결제 ID:', serverPaymentId);
+        const createPaymentData = createPaymentResult.data ?? {};
+
+        // 서버에서 생성한 paymentsId(PortOne paymentId)를 내려주지 않는 경우가 있어
+        // 여기서는 최대한 호환되게 파생합니다.
+        // - 권장: 백엔드가 PaymentTryResponse에 paymentsId(또는 paymentId)를 포함해 프론트에 내려주게 수정
+        const serverPaymentId =
+            createPaymentData.paymentId ||
+            createPaymentData.paymentsId ||
+            // PaymentTryResponse.id가 PortOne에서 사용하는 paymentId
+            (createPaymentData.id != null ? String(createPaymentData.id) : `payment_${Date.now()}`);
+
+        if (!createPaymentData.paymentId && !createPaymentData.paymentsId) {
+            console.warn(
+                '서버 응답에 PortOne paymentId가 없어 임시 paymentId를 사용합니다. ' +
+                '결제창은 열릴 수 있으나, 웹훅/상태 연동은 백엔드 수정이 필요할 수 있습니다.'
+            );
+        }
+
+        console.log('서버/임시 결제 ID:', serverPaymentId);
+
+        // 고객 정보는 /api/auth/me (get-current-user) 응답을 기준으로 PortOne 포맷에 맞춰 구성
+        // paymentData.customer가 이미 있으면 그걸 우선 사용하되, 비어있으면 보강
+        let customer = paymentData.customer;
+        const hasRequiredCustomerFields =
+            customer &&
+            customer.customerId &&
+            customer.fullName &&
+            customer.phoneNumber &&
+            customer.email;
+
+        if (!hasRequiredCustomerFields) {
+            const currentUser = await makeApiRequest('get-current-user', {});
+            const userData = currentUser?.data ?? currentUser ?? {};
+
+            customer = {
+                customerId: userData.customerUid,
+                fullName: userData.name,
+                phoneNumber: userData.phone || '01012345678',
+                email: userData.email
+            };
+        }
 
         // 2단계: PortOne 결제창 열기
         console.log('2단계: PortOne 결제창 열기...');
@@ -68,12 +107,7 @@ async function openPortOnePayment(paymentData) {
             totalAmount: paymentData.totalAmount,
             currency: paymentData.currency || 'KRW',
             payMethod: paymentData.payMethod || 'CARD',
-            customer: paymentData.customer || {
-                customerId: 'customer_001',
-                fullName: '홍길동',
-                phoneNumber: '01012345678',
-                email: 'customer@example.com'
-            },
+            customer: customer,
             redirectUrl: window.location.href,
             noticeUrls: paymentData.noticeUrls || []
         };
@@ -133,19 +167,17 @@ async function openPortOnePaymentWithPoints(paymentData) {
             throw new Error('kg-inicis 채널키가 설정되지 않았습니다.');
         }
 
-        // 포인트 검증
+        // 포인트 검증 (UI/요청 계산용; 백엔드 DTO에는 pointsToUse가 없으므로 서버에선 제외)
         const pointsToUse = paymentData.pointsToUse || 0;
-        if (pointsToUse < 0) {
-            throw new Error('포인트는 0 이상이어야 합니다.');
-        }
+        if (pointsToUse < 0) throw new Error('포인트는 0 이상이어야 합니다.');
 
-        // 1단계: 서버에 결제 시작 요청 (PENDING 상태로 DB 저장, 포인트 포함)
+        // 1단계: 서버에 결제 시작 요청 (PENDING 상태로 DB 저장)
+        // 백엔드 DTO: PaymentTryRequest.payment_price 만 받음
         console.log('1단계: 서버에 결제 시작 요청 (포인트 포함)...');
         const createPaymentResult = await makeApiRequest('create-payment', {
+            pathParams: { orderId: paymentData.orderId },
             body: {
-                orderId: paymentData.orderId,
-                totalAmount: paymentData.totalAmount,
-                pointsToUse: pointsToUse
+                payment_price: paymentData.backendPaymentPrice ?? paymentData.totalAmount
             }
         });
 
@@ -158,9 +190,44 @@ async function openPortOnePaymentWithPoints(paymentData) {
             throw new Error('결제 시작 요청 실패');
         }
 
-        // 서버에서 생성한 paymentId 사용
-        const serverPaymentId = createPaymentResult.paymentId;
-        console.log('서버에서 생성한 결제 ID:', serverPaymentId);
+        const createPaymentData = createPaymentResult.data ?? {};
+
+        const serverPaymentId =
+            createPaymentData.paymentId ||
+            createPaymentData.paymentsId ||
+            // PaymentTryResponse.id가 PortOne에서 사용하는 paymentId
+            (createPaymentData.id != null ? String(createPaymentData.id) : `payment_${Date.now()}`);
+
+        if (!createPaymentData.paymentId && !createPaymentData.paymentsId) {
+            console.warn(
+                '서버 응답에 PortOne paymentId가 없어 임시 paymentId를 사용합니다. ' +
+                '결제창은 열릴 수 있으나, 웹훅/상태 연동은 백엔드 수정이 필요할 수 있습니다.'
+            );
+        }
+
+        console.log('서버/임시 결제 ID:', serverPaymentId);
+
+        // 고객 정보는 /api/auth/me (get-current-user) 응답을 기준으로 PortOne 포맷에 맞춰 구성
+        // paymentData.customer가 이미 있으면 그걸 우선 사용하되, 비어있으면 보강
+        let customer = paymentData.customer;
+        const hasRequiredCustomerFields =
+            customer &&
+            customer.customerId &&
+            customer.fullName &&
+            customer.phoneNumber &&
+            customer.email;
+
+        if (!hasRequiredCustomerFields) {
+            const currentUser = await makeApiRequest('get-current-user', {});
+            const userData = currentUser?.data ?? currentUser ?? {};
+
+            customer = {
+                customerId: userData.customerUid,
+                fullName: userData.name,
+                phoneNumber: userData.phone || '01012345678',
+                email: userData.email
+            };
+        }
 
         // 포인트 차감 후 최종 금액 계산
         const finalAmount = Math.max(0, paymentData.totalAmount - pointsToUse);
@@ -176,12 +243,7 @@ async function openPortOnePaymentWithPoints(paymentData) {
             totalAmount: finalAmount,  // 포인트 차감 후 금액
             currency: paymentData.currency || 'KRW',
             payMethod: paymentData.payMethod || 'CARD',
-            customer: paymentData.customer || {
-                customerId: 'customer_001',
-                fullName: '홍길동',
-                phoneNumber: '01012345678',
-                email: 'customer@example.com'
-            },
+            customer: customer,
             redirectUrl: window.location.href,
             noticeUrls: paymentData.noticeUrls || []
         };

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -308,7 +308,7 @@
                     </td>
                     <td style="padding: 0.75rem; text-align: center;">
                         ${order.orderStatus === '결제 대기' ?
-                            `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderId}', ${finalAmount})">
+                            `<button class="btn btn-primary" style="padding: 0.5rem 1rem; font-size: 0.875rem;" onclick="payOrder('${order.orderId}')">
                                 💳 결제하기
                             </button>` :
                             `<span style="color: var(--text-secondary); font-size: 0.875rem;">-</span>`
@@ -321,7 +321,7 @@
         }
 
         // 주문 결제하기
-        async function payOrder(orderId, totalAmount) {
+        async function payOrder(orderId) {
             if (!currentUser) {
                 showNotification('⚠️ 사용자 정보를 먼저 로드해주세요', 'warning');
                 return;
@@ -335,10 +335,16 @@
             }
 
             try {
+                // 백엔드는 Order.totalPrice와 PaymentTryRequest.payment_price를 비교 중
+                // PortOne 결제창 금액은 사용자가 결제하는 최종 금액(paymentPrice)을 사용
+                const backendPaymentPrice = Number(order.totalPrice ?? 0);
+                const portOneTotalAmount = Number(order.paymentPrice ?? order.totalPrice ?? 0);
+
                 const paymentData = {
                     orderId: orderId,
                     orderName: `주문 ${order.orderNumber}`,  // 주문 번호로 표시
-                    totalAmount: totalAmount,
+                    totalAmount: portOneTotalAmount,
+                    backendPaymentPrice: backendPaymentPrice,
                     currency: 'KRW',
                     payMethod: 'CARD',
                     customer: {

--- a/src/main/resources/templates/points.html
+++ b/src/main/resources/templates/points.html
@@ -225,12 +225,28 @@
                     return;
                 }
 
-                if (result && Array.isArray(result)) {
-                    orders = result;
-                    renderOrders();
-                } else {
+                // backend 공통 응답 래퍼:
+                // { success, data: { orders: [...] , pagination: {...}}, message }
+                const extractedOrders = result?.data?.orders;
+
+                if (!Array.isArray(extractedOrders)) {
                     showNotification('주문 목록이 배열 형식이 아닙니다', 'error');
+                    return;
                 }
+
+                // points.html 내부 렌더링은 아래 필드명을 사용 중
+                orders = extractedOrders.map(order => ({
+                    orderId: order.orderId,
+                    orderNumber: order.orderNumber,
+                    // paymentPrice가 "실결제" 성격이므로 우선 사용
+                    totalAmount: Number(order.paymentPrice ?? order.totalPrice ?? 0),
+                    // renderOrders에서 쓰는 status 필드 매핑
+                    status: order.orderStatus,
+                    createdAt: order.orderedCreatedAt,
+                    currency: 'KRW'
+                }));
+
+                renderOrders();
             } catch (error) {
                 console.error('Failed to load orders:', error);
                 showNotification('주문 목록을 불러올 수 없습니다', 'error');
@@ -249,7 +265,9 @@
             }
 
             // PENDING 상태의 주문만 필터링
-            const pendingOrders = orders.filter(order => order.status === 'PENDING');
+            const pendingOrders = orders.filter(order =>
+                order.status === 'PENDING' || order.status === '결제 대기'
+            );
 
             if (pendingOrders.length === 0) {
                 container.innerHTML = '<p style="color: var(--text-secondary); text-align: center; padding: 2rem;">결제 대기 중인 주문이 없습니다</p>';
@@ -257,8 +275,10 @@
             }
 
             const ordersHtml = pendingOrders.map(order => {
-                const statusClass = order.status === 'PENDING' ? 'warning' :
-                                  order.status === 'PAID' ? 'success' : 'secondary';
+                const statusClass =
+                    order.status === 'PENDING' || order.status === '결제 대기' ? 'warning' :
+                    order.status === 'PAID' || order.status === '결제 완료' ? 'success' :
+                    'secondary';
 
                 return `
                     <div style="padding: 1rem; background: var(--bg-secondary); border-radius: var(--radius-md); margin-bottom: 1rem;">
@@ -296,7 +316,8 @@
         // 포인트 모달 열기
         function openPointsModal(orderId) {
             // orders 배열에서 orderId로 주문 찾기
-            const order = orders.find(o => o.orderId === orderId);
+            // orderId는 onclick에서 문자열로 들어올 수 있으므로 타입을 통일해 비교
+            const order = orders.find(o => String(o.orderId) === String(orderId));
 
             if (!order) {
                 showNotification('주문을 찾을 수 없습니다', 'error');


### PR DESCRIPTION
## 주요 변경사항

1. orders.html의 “결제하기” 버튼 클릭 시 백엔드 결제 생성 POST를 먼저 호출한 뒤 PortOne 결제창을 열도록 프론트 흐름을 정리했습니다.
2. points.html에서 list-orders 응답(공통 래퍼)을 올바르게 파싱해 주문 목록이 렌더링되도록 수정했고, “포인트로 결제” 모달이 정상 열리도록 타입 매칭 이슈도 함께 해결했습니다.
3. PortOne 연동에서 결제 생성 요청 스펙을 백엔드 계약(payment_price, pathParams.orderId)에 맞추고, 고객 정보는 /api/auth/me 응답을 활용하도록 보강했습니다.
4. 백엔드 Payment 엔티티의 createdAt 중복 선언으로 인한 DB CREATED_AT NOT NULL 오류를 제거했습니다.
