### PR TITLE
membership 도메인 수정

### DIFF
--- a/src/main/java/com/example/paymentsystem/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/paymentsystem/common/exception/ErrorCode.java
@@ -24,13 +24,23 @@ public enum ErrorCode {
     INVALID_USED_POINT(HttpStatus.BAD_REQUEST, "사용 포인트가 올바르지 않습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "주문 상품은 최소 1개 이상이어야 합니다."),
     // point
+    POINT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "사용한 포인트 내역이 없습니다."),
+    EARNED_POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "적립된 포인트 내역이 없습니다."),
 
     // user
 
     // refund
-    REFUND_NO_AUTHORITY(HttpStatus.FORBIDDEN,  "해당 환불에 권한이 없습니다.");
+    REFUND_NO_AUTHORITY(HttpStatus.FORBIDDEN,  "해당 환불에 권한이 없습니다."),
+    ALREADY_REFUNDED(HttpStatus.BAD_REQUEST, "이미 환불 처리가 완료된 결제건입니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 결제 정보를 찾을 수 없습니다."),
+    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "결제 완료 상태인 경우에만 환불이 가능합니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 완료인 상태만 환불이 가능합니다."),
+    REFUND_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문의 환불 내역이 없습니다."),
 
     // membership
+
+    MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버십 정보가 없습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/paymentsystem/domain/membership/controller/MembershipController.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/controller/MembershipController.java
@@ -1,0 +1,37 @@
+package com.example.paymentsystem.domain.membership.controller;
+
+import com.example.paymentsystem.common.dto.ApiResponse;
+import com.example.paymentsystem.domain.membership.dto.GetMembershipTierResponse;
+import com.example.paymentsystem.domain.membership.dto.GetMyMembershipResponse;
+import com.example.paymentsystem.domain.membership.service.MembershipService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MembershipController {
+
+    private final MembershipService membershipService;
+
+    // 멤버십 등급 정책 조회
+    @GetMapping("/membership/tiers")
+    public ResponseEntity<ApiResponse<List<GetMembershipTierResponse>>> getMembershipTiers() {
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(membershipService.getMembershipTier()));
+    }
+
+    // 유저의 멤버십 등급 조회
+    @GetMapping("/membership/me")
+    public ResponseEntity<ApiResponse<GetMyMembershipResponse>> getMyMembership(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(membershipService.getMyMembership(userId)));
+    }
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/dto/GetMembershipTierResponse.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/dto/GetMembershipTierResponse.java
@@ -1,0 +1,27 @@
+package com.example.paymentsystem.domain.membership.dto;
+
+import com.example.paymentsystem.domain.membership.entity.MembershipName;
+import com.example.paymentsystem.domain.membership.entity.MembershipTier;
+
+// 멤버십 등급 정책 DTO
+public record GetMembershipTierResponse(
+        Long id,
+        Double rewardRate,
+        String promotionCriteria,
+        MembershipName membershipName,
+        Long minPrice,
+        Long maxPrice
+
+) {
+    public GetMembershipTierResponse(MembershipTier membershipTier) {
+        this(
+                membershipTier.getId(),
+                membershipTier.getRewardRate(),
+                membershipTier.getPromotionCriteria(),
+                membershipTier.getMembershipName(),
+                membershipTier.getMinPrice(),
+                membershipTier.getMaxPrice()
+        );
+    }
+}
+

--- a/src/main/java/com/example/paymentsystem/domain/membership/dto/GetMyMembershipResponse.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/dto/GetMyMembershipResponse.java
@@ -1,0 +1,25 @@
+package com.example.paymentsystem.domain.membership.dto;
+
+import com.example.paymentsystem.domain.membership.entity.MembershipName;
+import com.example.paymentsystem.domain.membership.entity.UserMembership;
+
+import java.time.LocalDateTime;
+
+// 유저의 멤버십 DTO
+public record GetMyMembershipResponse (
+        Long id,
+        Long userId,
+        MembershipName gradeNow,
+        Long totalPrice,
+        LocalDateTime gradeUpdatedAt
+){
+    public GetMyMembershipResponse(UserMembership userMembership){
+        this(
+                userMembership.getId(),
+                userMembership.getUser().getId(),
+                userMembership.getGradeNow(),
+                userMembership.getTotalPrice(),
+                userMembership.getGradeUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/entity/MembershipName.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/entity/MembershipName.java
@@ -1,0 +1,15 @@
+package com.example.paymentsystem.domain.membership.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MembershipName {
+
+    NORMAL("일반 등급"),
+    VIP("우수 등급"),
+    VVIP("최우수 등급");
+
+    private final String name;
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/entity/MembershipTier.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/entity/MembershipTier.java
@@ -1,0 +1,43 @@
+package com.example.paymentsystem.domain.membership.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "membership_tiers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MembershipTier {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Double rewardRate;
+
+    // 승급 기준
+    @Column(nullable = false)
+    private String promotionCriteria;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MembershipName membershipName;
+
+    @Column(nullable = false)
+    private Long minPrice;
+
+    private Long maxPrice;
+
+
+    public MembershipTier(Double rewardRate, String promotionCriteria, MembershipName membershipName, Long minPrice, Long maxPrice) {
+        this.rewardRate = rewardRate;
+        this.promotionCriteria = promotionCriteria;
+        this.membershipName = membershipName;
+        this.minPrice = minPrice;
+        this.maxPrice = maxPrice;
+    }
+
+
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/entity/UserMembership.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/entity/UserMembership.java
@@ -1,0 +1,61 @@
+package com.example.paymentsystem.domain.membership.entity;
+
+import com.example.paymentsystem.domain.auth.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "user_memberships")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserMembership {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    MembershipName gradeNow;
+
+    @Column(nullable = false)
+    private Long totalPrice;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime gradeUpdatedAt;
+
+    // 처음 생성시 기본등급, 총결제금 0원으로
+    public UserMembership(User user) {
+        this.user = user;
+        this.gradeNow = MembershipName.NORMAL;
+        this.totalPrice = 0L;
+    }
+
+    // 등급 계산 로직
+    private MembershipName recalculatingGrade(Long totalPrice) {
+        if (totalPrice <= 50000) {
+            return MembershipName.NORMAL;
+        } else if (totalPrice <= 100000){
+            return MembershipName.VIP;
+        } else {
+            return MembershipName.VVIP;
+        }
+    }
+
+    // 총 결제 금액 업데이트 및 등급 재 계산
+    public void updateTotalPriceAndGrade(Long totalPrice) {
+        this.totalPrice += totalPrice;
+        this.gradeNow = recalculatingGrade(this.totalPrice);
+    }
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/repository/MembershipTierRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/repository/MembershipTierRepository.java
@@ -1,0 +1,7 @@
+package com.example.paymentsystem.domain.membership.repository;
+
+import com.example.paymentsystem.domain.membership.entity.MembershipTier;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MembershipTierRepository extends JpaRepository<MembershipTier, Long> {
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/repository/UserMembershipRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/repository/UserMembershipRepository.java
@@ -1,0 +1,10 @@
+package com.example.paymentsystem.domain.membership.repository;
+
+import com.example.paymentsystem.domain.membership.entity.UserMembership;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserMembershipRepository extends JpaRepository<UserMembership, Long> {
+    Optional<UserMembership> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/service/MembershipService.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/service/MembershipService.java
@@ -1,0 +1,60 @@
+package com.example.paymentsystem.domain.membership.service;
+
+import com.example.paymentsystem.common.exception.ErrorCode;
+import com.example.paymentsystem.common.exception.ServiceException;
+import com.example.paymentsystem.domain.auth.entity.User;
+import com.example.paymentsystem.domain.auth.repository.UserRepository;
+import com.example.paymentsystem.domain.membership.dto.GetMembershipTierResponse;
+import com.example.paymentsystem.domain.membership.dto.GetMyMembershipResponse;
+import com.example.paymentsystem.domain.membership.entity.UserMembership;
+import com.example.paymentsystem.domain.membership.repository.MembershipTierRepository;
+import com.example.paymentsystem.domain.membership.repository.UserMembershipRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipService {
+
+    private final MembershipTierRepository membershipTierRepository;
+    private final UserRepository userRepository;
+    private final UserMembershipRepository userMembershipRepository;
+
+    // 멤버십 등급 정책 조회 (MembershipTier)
+    @Transactional(readOnly = true)
+    public List<GetMembershipTierResponse> getMembershipTier() {
+        return membershipTierRepository.findAll().stream()
+                .map(GetMembershipTierResponse::new)
+                .toList();
+    }
+
+    // 유저의 멤버십 등급 조회 (UserMembership)
+    @Transactional(readOnly = true)
+    public GetMyMembershipResponse getMyMembership(Long userId) {
+        // 1. 유저 조회
+        userRepository.findById(userId).orElseThrow(
+                () -> new ServiceException(ErrorCode.USER_NOT_FOUND)
+        );
+        // 2. 유저의 멤버십 정보 조회
+        UserMembership userMembership = userMembershipRepository.findByUserId(userId).orElseThrow(
+                () -> new ServiceException(ErrorCode.MEMBERSHIP_NOT_FOUND)
+        );
+
+        return new GetMyMembershipResponse(userMembership);
+    }
+
+    // 등급 갱신
+    @Transactional
+    public void updateMembership(User user, Long totalPaidPrice) {
+        // 1. 유저의 멤버십 조회
+        UserMembership userMembership = userMembershipRepository.findByUserId(user.getId()).orElseThrow(
+                () -> new ServiceException(ErrorCode.MEMBERSHIP_NOT_FOUND)
+        );
+        // 엔티티로 등급 계산 넘김
+        userMembership.updateTotalPriceAndGrade(totalPaidPrice);
+        userMembershipRepository.save(userMembership);
+    }
+}

--- a/src/main/java/com/example/paymentsystem/domain/membership/service/MembershipService.java
+++ b/src/main/java/com/example/paymentsystem/domain/membership/service/MembershipService.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MembershipService {
 
     private final MembershipTierRepository membershipTierRepository;
@@ -24,7 +25,6 @@ public class MembershipService {
     private final UserMembershipRepository userMembershipRepository;
 
     // 멤버십 등급 정책 조회 (MembershipTier)
-    @Transactional(readOnly = true)
     public List<GetMembershipTierResponse> getMembershipTier() {
         return membershipTierRepository.findAll().stream()
                 .map(GetMembershipTierResponse::new)
@@ -32,7 +32,6 @@ public class MembershipService {
     }
 
     // 유저의 멤버십 등급 조회 (UserMembership)
-    @Transactional(readOnly = true)
     public GetMyMembershipResponse getMyMembership(Long userId) {
         // 1. 유저 조회
         userRepository.findById(userId).orElseThrow(
@@ -55,6 +54,5 @@ public class MembershipService {
         );
         // 엔티티로 등급 계산 넘김
         userMembership.updateTotalPriceAndGrade(totalPaidPrice);
-        userMembershipRepository.save(userMembership);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (선택)
#69 

## 🛠 작업 내용
> 멤버십 도메인 수

## 💻 주요 변경사항
- membershipTier -> membership으로 도메인 이름 변경
- MembershipTierController -> MembershipController로 변경
- MembershipTierService -> MembershipService로 변경
- UserMembershipEntity 추가

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 네이밍 컨벤션 준수

## 📷 스크린샷 (선택)

