### PR TITLE
refactor : 포트원서비스 코드 개선

### DIFF
--- a/src/main/java/com/example/paymentsystem/common/config/AppConfig.java
+++ b/src/main/java/com/example/paymentsystem/common/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.example.paymentsystem.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/paymentsystem/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/paymentsystem/common/exception/ErrorCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // payment
-
+    PORTONE_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "포트원 인증에 실패했습니다."), // 401
+    PORTONE_FORBIDDEN(HttpStatus.FORBIDDEN, "포트원 API 접근 권한이 없습니다."), // 403
+    ALREADY_CANCELLED_PAYMENT(HttpStatus.CONFLICT, "이미 취소된 결제 건입니다."), // 409
+    PORTONE_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 포트원 API 오류가 발생했습니다."),
+    PORTONE_SERVER_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "포트원 서버 연결에 실패했습니다."),
     // auth
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일 입니다."),
     DUPLICATED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 가입된 전화번호 입니다."),

--- a/src/main/java/com/example/paymentsystem/domain/payment/service/PortOneService.java
+++ b/src/main/java/com/example/paymentsystem/domain/payment/service/PortOneService.java
@@ -1,5 +1,7 @@
 package com.example.paymentsystem.domain.payment.service;
 
+import com.example.paymentsystem.common.exception.ErrorCode;
+import com.example.paymentsystem.common.exception.ServiceException;
 import com.example.paymentsystem.common.properties.PortOneProperties;
 import com.example.paymentsystem.domain.payment.dto.CancelRequestDto;
 import com.example.paymentsystem.domain.payment.dto.CancelResponseDto;
@@ -24,7 +26,8 @@ import java.util.Map;
 public class PortOneService {
 
     private final PortOneProperties portOneProperties;//키불러오기위해
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+    private static final String PORTONE_URL = "https://api.portone.io/payments/";
 
     //공통헤더
     private HttpHeaders createHeaders() {
@@ -34,10 +37,23 @@ public class PortOneService {
         return headers;
     }
 
+    //공통에러
+    private ServiceException handlePortOneError(HttpClientErrorException e) {
+        return switch (e.getStatusCode().value()) {
+            case 401 -> new ServiceException(ErrorCode.PORTONE_AUTHENTICATION_FAILED);
+            case 403 -> new ServiceException(ErrorCode.PORTONE_FORBIDDEN);
+            case 404 -> new ServiceException(ErrorCode.PAYMENT_NOT_FOUND);
+            case 409 -> new ServiceException(ErrorCode.ALREADY_CANCELLED_PAYMENT);
+            default -> new ServiceException(
+                    ErrorCode.PORTONE_API_ERROR,
+                    "포트원 API 오류: " + e.getStatusCode());
+        };
+    }
+
     //결제 검증
     public PortOneVerificationResponseDto getVerifyPayment(String paymentId) {
         try {
-            String portOneUrl = "https://api.portone.io/payments/" + paymentId;
+            String portOneUrl = PORTONE_URL + paymentId;
 
             HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
 
@@ -50,11 +66,7 @@ public class PortOneService {
 
         } catch (HttpClientErrorException e) {
             log.error("포트원 API 오류: {}", e.getStatusCode());
-            switch (e.getStatusCode().value()) {
-                case 401, 403 -> throw new RuntimeException("포트원 인증 실패: 시크릿 키를 확인해주세요.");
-                case 404 -> throw new RuntimeException("존재하지 않는 paymentId입니다.");
-                default -> throw new RuntimeException("포트원 API 오류: " + e.getStatusCode());
-            }
+            throw handlePortOneError(e);//공통에러 메서드 사용
         } catch (Exception e) {
             log.error("포트원 서버 연결 오류: {}", e.getMessage());
             throw new RuntimeException("포트원 서버 연결에 실패했습니다.");
@@ -64,7 +76,7 @@ public class PortOneService {
     //결제 취소
     public CancelResponseDto cancelPayment(String paymentId, CancelRequestDto request) {
         try {
-            String portOneUrl = "https://api.portone.io/payments/" + paymentId + "/cancel";
+            String portOneUrl = PORTONE_URL + paymentId + "/cancel";
 
             Map<String, Object> body = new HashMap<>();
             if (StringUtils.hasText(request.reason())) {
@@ -82,15 +94,10 @@ public class PortOneService {
 
         } catch (HttpClientErrorException e) {
             log.error("포트원 취소 오류: {}", e.getStatusCode());
-            switch (e.getStatusCode().value()) {
-                case 401, 403 -> throw new RuntimeException("포트원 인증 실패");
-                case 404 -> throw new RuntimeException("존재하지 않는 paymentId입니다.");
-                case 409 -> throw new RuntimeException("이미 취소된 결제입니다.");
-                default -> throw new RuntimeException("포트원 취소 API 오류: " + e.getStatusCode());
-            }
+            throw handlePortOneError(e);
         } catch (Exception e) {
             log.error("포트원 서버 연결 오류: {}", e.getMessage());
-            throw new RuntimeException("포트원 서버 연결에 실패했습니다.");
+            throw new ServiceException(ErrorCode.PORTONE_SERVER_CONNECTION_FAILED);
         }
     }
 }


### PR DESCRIPTION
## 🛠 작업 내용
> 예외처리 ServiceException으로 처리 및 에러 추가
> 공통예외처리 메서드로 분리
> 포트원 공통url상수처리
> restTemplate 빈으로 주입받도록 수정

## 💻 주요 변경사항
- [x]  https://api.portone.io/payments/ 상수로 관리하기 ⇒ `PORTONE_URL`
- [x]  ServiceException 나중에 활용하기 → `ErrorCode에 결제쪽 추가`
- [x]  PortOneService 예외처러 catch부분 따로빼보기→`handlePortOneError`
- [x]  `restTemplate 빈으로 관리해보기 => common>config>AppConfig(restTemplate) 추가`

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 네이밍 컨벤션 준수

## 📷 스크린샷 (선택)
> API 테스트 결과, 변경된 화면 등 첨부
