### PR TITLE
refactor: 포인트 거래내역 조회 페이징, 포인트 지급액 변경

### DIFF
--- a/src/main/java/com/example/paymentsystem/domain/auth/entity/User.java
+++ b/src/main/java/com/example/paymentsystem/domain/auth/entity/User.java
@@ -54,7 +54,7 @@ public class User extends BaseEntity {
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.role = (role != null) ? role : UserRole.USER;
-        this.point = 0L;
+        this.point = 1000000L;
     }
 
     public void updatePoint(Long amount) {

--- a/src/main/java/com/example/paymentsystem/domain/pointHistory/controller/PointHistoryController.java
+++ b/src/main/java/com/example/paymentsystem/domain/pointHistory/controller/PointHistoryController.java
@@ -18,15 +18,9 @@ import org.springframework.web.bind.annotation.*;
 public class PointHistoryController {
     private final PointHistoryService pointHistoryService;
 
-    // 현재 내 포인트 조회
-//    @GetMapping("/me")
-//    public ResponseEntity<ApiResponse<GetMyPointHistoryResponse>> getMyPoint(
-//            @RequestParam Long userId
-//    ) {
-//        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(pointHistoryService.getMyPoint(userId)));
-//    }
+    // 포인트 거래 내역 조회
     @GetMapping("/me/history")
-    public ResponseEntity<ApiResponse<Page<GetPointTransactionHistory>>> getPointTransactionHistory(
+    public ResponseEntity<ApiResponse<GetPointTransactionHistory>> getPointTransactionHistory(
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/com/example/paymentsystem/domain/pointHistory/dto/GetPointTransactionHistory.java
+++ b/src/main/java/com/example/paymentsystem/domain/pointHistory/dto/GetPointTransactionHistory.java
@@ -1,14 +1,19 @@
 package com.example.paymentsystem.domain.pointHistory.dto;
 
+import com.example.paymentsystem.domain.pointHistory.entity.PointHistory;
 import com.example.paymentsystem.domain.pointHistory.entity.Type;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+// 최종 응답용 커스텀 DTO
 public record GetPointTransactionHistory (
-        Long id,
-        Long orderId,
-        Long point,
-        Type type,
-        LocalDateTime createdAt,
-        LocalDateTime expiredAt
-){}
+        // 편지 묶음
+        List<PointHistorySummaryResponse> pointHistory,
+        // 응답에 나갈 Page 필드값들
+        int currentPage,
+        int size,
+        long totalCount,
+        int totalPages
+) {}
+

--- a/src/main/java/com/example/paymentsystem/domain/pointHistory/dto/PointHistorySummaryResponse.java
+++ b/src/main/java/com/example/paymentsystem/domain/pointHistory/dto/PointHistorySummaryResponse.java
@@ -1,0 +1,29 @@
+package com.example.paymentsystem.domain.pointHistory.dto;
+
+import com.example.paymentsystem.domain.pointHistory.entity.PointHistory;
+import com.example.paymentsystem.domain.pointHistory.entity.Type;
+
+import java.time.LocalDateTime;
+// 응답 목록에 들어갈 데이터 한 건 정의하는 DTO,
+// ex) 편지 1장에 적혀있는 내용
+public record PointHistorySummaryResponse(
+        Long id,
+        Long orderId,
+        Long point,
+        Type type,
+        LocalDateTime createdAt,
+        LocalDateTime expiredAt
+) {
+    public PointHistorySummaryResponse(PointHistory pointHistory) {
+        this(
+                pointHistory.getId(),
+                pointHistory.getOrder().getId() != null ? pointHistory.getOrder().getId() : null,
+                // OrderId는 NOTNULL이 아니기 때문에, null 체크
+                pointHistory.getPoint(),
+                pointHistory.getType(),
+                pointHistory.getCreatedAt(),
+                pointHistory.getExpiredAt()
+        );
+    }
+}
+

--- a/src/main/java/com/example/paymentsystem/domain/pointHistory/repository/PointHistoryRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/pointHistory/repository/PointHistoryRepository.java
@@ -3,6 +3,7 @@ package com.example.paymentsystem.domain.pointHistory.repository;
 import com.example.paymentsystem.domain.auth.entity.User;
 import com.example.paymentsystem.domain.order.entity.Order;
 import com.example.paymentsystem.domain.pointHistory.dto.GetPointTransactionHistory;
+import com.example.paymentsystem.domain.pointHistory.dto.PointHistorySummaryResponse;
 import com.example.paymentsystem.domain.pointHistory.entity.PointHistory;
 import com.example.paymentsystem.domain.pointHistory.entity.Type;
 import org.springframework.data.domain.Page;
@@ -20,7 +21,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
     @Query("SELECT SUM(p.point) FROM PointHistory p WHERE p.user = :user")
     Long sumPointByUser(@Param("user") User user);
 
-    Page<GetPointTransactionHistory> findAllByUser(User user, Pageable pageable);
+    Page<PointHistory> findAllByUser(User user, Pageable pageable);
 
     boolean existsByOrderAndType(Order order, Type type);
 }

--- a/src/main/java/com/example/paymentsystem/domain/pointHistory/service/PointHistoryService.java
+++ b/src/main/java/com/example/paymentsystem/domain/pointHistory/service/PointHistoryService.java
@@ -4,17 +4,15 @@ import com.example.paymentsystem.common.exception.ErrorCode;
 import com.example.paymentsystem.common.exception.ServiceException;
 import com.example.paymentsystem.domain.auth.entity.User;
 import com.example.paymentsystem.domain.auth.repository.UserRepository;
-import com.example.paymentsystem.domain.membership.entity.MembershipTier;
-import com.example.paymentsystem.domain.membership.entity.UserMembership;
 import com.example.paymentsystem.domain.membership.repository.MembershipTierRepository;
 import com.example.paymentsystem.domain.membership.repository.UserMembershipRepository;
 import com.example.paymentsystem.domain.order.entity.Order;
 import com.example.paymentsystem.domain.order.entity.OrderStatus;
 import com.example.paymentsystem.domain.order.repository.OrderRepository;
-import com.example.paymentsystem.domain.payment.entity.Payment;
 import com.example.paymentsystem.domain.payment.entity.PaymentStatus;
 import com.example.paymentsystem.domain.payment.repository.PaymentRepository;
 import com.example.paymentsystem.domain.pointHistory.dto.GetPointTransactionHistory;
+import com.example.paymentsystem.domain.pointHistory.dto.PointHistorySummaryResponse;
 import com.example.paymentsystem.domain.pointHistory.entity.PointHistory;
 import com.example.paymentsystem.domain.pointHistory.entity.Type;
 import com.example.paymentsystem.domain.pointHistory.repository.PointHistoryRepository;
@@ -23,6 +21,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -36,13 +36,6 @@ public class PointHistoryService {
     private final PaymentRepository paymentRepository;
 
     private static final Long MIN_USE_POINT = 1000L; // 예: 1000원부터 사용 가능
-//    @Transactional(readOnly = true)
-//    public GetMyPointHistoryResponse getMyPoint(Long userId) {
-//        User user = userRepository.findById(userId).orElseThrow(
-//                () -> new IllegalArgumentException("유저를 찾지 못했습니다.")
-//        );
-//        return new GetMyPointHistoryResponse(user.getId(), user.getPoint());
-//    }
 
     /*현재 포인트 잔액 계산(합산)
 
@@ -69,7 +62,8 @@ public class PointHistoryService {
         Double rewardRate = membershipTierRepository.findRewardRateByUserId(user.getId())
                 .orElseThrow(() -> new ServiceException(ErrorCode.MEMBERSHIP_NOT_FOUND));
         // rewardRate는 Double 타입이므로, long타입으로 형변환 후 받아줌
-        Long earnPrice = (long) Math.floor(order.getTotalPrice() * rewardRate);
+        Long earnPrice = (long) Math.floor(order.getPaymentPrice() * rewardRate);
+        // order.getTotalPrice() -> order.getPaymentPrice()로 변경
 
         PointHistory earnedPoint = new PointHistory(earnPrice, Type.EARNED, user, order);
 
@@ -80,23 +74,27 @@ public class PointHistoryService {
 
     // 포인트 사용 (결제 시)
     @Transactional
-    public void usePoint(Long userId, Order order, Long price) {
-        if (price < MIN_USE_POINT) {
+    public void usePoint(Long userId, Order order) {
+
+        Long usedPoint = order.getUsedPoint();
+
+        if (usedPoint < MIN_USE_POINT) {
             throw new ServiceException(ErrorCode.POINT_BELOW_MINIMUM);
         }
 
         // 비관적 락을 통해 유저 정보 재조회 (동시성 방지)
         User user = userRepository.findByIdWithPessimisticLock(userId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
-        // 잔액이 부족한지 체크
-        if (user.getPoint() < price) {
+
+        // 사용할 수 있는 포인트가 있는지 체크
+        if (user.getPoint() < usedPoint) {
             throw new ServiceException(ErrorCode.INSUFFICIENT_POINT);
         }
 
-        PointHistory spentPoint = new PointHistory(-price, Type.SPENT, user, order);
+        PointHistory spentPoint = new PointHistory(-usedPoint, Type.SPENT, user, order);
         pointHistoryRepository.save(spentPoint);
 
-        user.updatePoint(-price);
+        user.updatePoint(-usedPoint);
     }
 
     // 포인트 복구
@@ -163,12 +161,25 @@ public class PointHistoryService {
 
     // 포인트 거래 내역 조회
     @Transactional(readOnly = true)
-    public Page<GetPointTransactionHistory> getPointTransactionHistory(Long userId, Pageable pageable) {
+    public GetPointTransactionHistory getPointTransactionHistory(Long userId, Pageable pageable) {
+
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new ServiceException(ErrorCode.USER_NOT_FOUND)
         );
-        return pointHistoryRepository.findAllByUser(user, pageable);
 
+        Page<PointHistory> page = pointHistoryRepository.findAllByUser(user, pageable);
+
+        List<PointHistorySummaryResponse> pointHistoryList = page.getContent().stream()
+                .map(PointHistorySummaryResponse::new)
+                .toList();
+
+        return new GetPointTransactionHistory(
+                pointHistoryList,
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
     }
 }
 

--- a/src/main/java/com/example/paymentsystem/domain/refund/service/RefundService.java
+++ b/src/main/java/com/example/paymentsystem/domain/refund/service/RefundService.java
@@ -46,22 +46,6 @@ public class RefundService {
         validateOrderStatus(payment);
         validateAlreadyRefundRecord(payment);
 
-        // 결제 상태 검증
-        if (payment.getPaymentStatus() != PaymentStatus.PAID) {
-            throw new ServiceException(ErrorCode.INVALID_PAYMENT_STATUS);
-        }
-        // 주문 상태 검증
-        if (payment.getOrder().getOrderStatus() != OrderStatus.ORDER_COMPLETED) {
-            throw new ServiceException(ErrorCode.INVALID_ORDER_STATUS);
-        }
-
-        // 이미 환불 레코드가 존재하는지
-        if (refundRepository.existsByPayment(payment)) {
-            throw new ServiceException(ErrorCode.ALREADY_REFUNDED);
-        }
-
-
-
         // 환불 레코드 엔티티 내부로 캡슐화
         Refund refund = Refund.of(payment, request.refundReason());
 


### PR DESCRIPTION
## 📌 관련 이슈 (선택)
#92 

## 🛠 작업 내용
> 포인트 거래내역 조회 페이징
> 포인트 지급액 변경
> RefundService 중복 로직 삭제

## 💻 주요 변경사항
- PointHistorySummaryResponse
- GetPointTransactionHistory 응답용 커스텀 DTO
- 0L -> 1000000L

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 네이밍 컨벤션 준수

## 📷 스크린샷 (선택)

