### PR TITLE
feat: 포인트만으로 결제할 수 있도록 예외 수정, 결제 확정시 재고만 차감되도록 수정

### DIFF
--- a/src/main/java/com/example/paymentsystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/paymentsystem/domain/order/service/OrderService.java
@@ -189,4 +189,17 @@ public class OrderService {
     public void completeOrder(Order order) {
         order.complete();
     }
+
+    @Transactional
+    public void stockReduce(Order order) {
+        // 1. 주문 항목 가져옴
+        List<OrderItem> orderItems = order.getOrderItems();
+
+        for (OrderItem item : orderItems) {
+            Product product = productRepository.findById(item.getProductId())
+                    .orElseThrow(() -> new ServiceException(ErrorCode.PRODUCT_NOT_FOUND));
+
+            product.removeStock(item.getQuantity());
+        }
+    }
 }

--- a/src/main/java/com/example/paymentsystem/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/paymentsystem/domain/payment/service/PaymentService.java
@@ -94,6 +94,7 @@ public class PaymentService {
         }
 
         // 6. 재고 차감
+        payment.stateUpdate(PaymentStatus.PAID);
         orderService.stockReduce(payment.getOrder());
     }
 

--- a/src/main/java/com/example/paymentsystem/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/paymentsystem/domain/payment/service/PaymentService.java
@@ -59,7 +59,7 @@ public class PaymentService {
                 order,
                 generatedPaymentId,
                 PaymentStatus.PENDING,
-                order.getTotalPrice()
+                order.getPaymentPrice()
         );
 
         return new PaymentTryResponse(paymentRepository.save(saved));
@@ -68,16 +68,19 @@ public class PaymentService {
     @Transactional
     public void confirmPayment(String paymentId) {
 
-        // 1. 포트원 서버에서 실제 결제 내역 조회
-        PortOneVerificationResponseDto portOneData = portApiService.getVerifyPayment(paymentId);
-
-        // 2. 우리 DB에서 결제 시도 정보 조회
         Payment payment = paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.PAYMENT_NOT_FOUND));
 
+        if (payment.getPaymentPrice() == 0) {
+            orderService.stockReduce(payment.getOrder());
+            return;
+        }
+
+        PortOneVerificationResponseDto portOneData = portApiService.getVerifyPayment(paymentId);
+
         // 3. 중복 처리 방지 (이미 완료된 경우 예외)
         if (payment.getPaymentStatus() == PaymentStatus.PAID) {
-            throw new ServiceException(ErrorCode.ALREADY_PAID);
+            return;
         }
 
         // 4. 포트원 결제 상태 확인 (PAID 여부)
@@ -90,15 +93,8 @@ public class PaymentService {
             throw new ServiceException(ErrorCode.PAYMENT_FORGERY_DETECTED);
         }
 
-        Order order = payment.getOrder();
-
-        // 6. 상태 업데이트 및 비즈니스 로직 수행
-        payment.stateUpdate(PaymentStatus.PAID);
-        orderService.completeOrder(order);
-        orderService.confirmOrder(
-                order.getId(),
-                order.getUser().getId()
-        );
+        // 6. 재고 차감
+        orderService.stockReduce(payment.getOrder());
     }
 
     private void handleSecurityIssue(String impUid, String token) {

--- a/src/main/java/com/example/paymentsystem/domain/pointHistory/service/PointHistoryService.java
+++ b/src/main/java/com/example/paymentsystem/domain/pointHistory/service/PointHistoryService.java
@@ -60,7 +60,7 @@ public class PointHistoryService {
         }
         // 현재 등급에 해당되는 등급 정책 조회
         Double rewardRate = membershipTierRepository.findRewardRateByUserId(user.getId())
-                .orElseThrow(() -> new ServiceException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+                .orElseThrow(() ->  new ServiceException(ErrorCode.MEMBERSHIP_NOT_FOUND));
         // rewardRate는 Double 타입이므로, long타입으로 형변환 후 받아줌
         Long earnPrice = (long) Math.floor(order.getPaymentPrice() * rewardRate);
         // order.getTotalPrice() -> order.getPaymentPrice()로 변경


### PR DESCRIPTION

## 🛠 작업 내용
> 포인트만으로 결제할 수 있도록 예외 수정, 결제 확정시 재고만 차감되도록 수정

## 💻 주요 변경사항
<img width="1074" height="407" alt="image" src="https://github.com/user-attachments/assets/4a77ce8a-8648-43e8-9dde-8a6c412a540e" />

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 네이밍 컨벤션 준수


