### PR TITLE
feat: 재고 차감 / 주문 확정에 비관적 락 적용

### DIFF
--- a/src/main/java/com/example/paymentsystem/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/order/repository/OrderRepository.java
@@ -2,10 +2,12 @@ package com.example.paymentsystem.domain.order.repository;
 
 import com.example.paymentsystem.domain.order.entity.Order;
 import com.example.paymentsystem.domain.order.entity.OrderStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,6 +18,14 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findByIdAndUserId(Long orderId, Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select o from Order o where o.id = :orderId and o.user.id = :userId")
+    Optional<Order> findByIdAndUserIdWithPessimisticLock(@Param("orderId") Long orderId, @Param("userId") Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select o from Order o where o.id = :id")
+    Optional<Order> findByIdWithPessimisticLock(@Param("id") Long id);
 
     @EntityGraph(attributePaths = "user")
     Page<Order> findByUserId(Long userId, Pageable pageable);

--- a/src/main/java/com/example/paymentsystem/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/paymentsystem/domain/order/service/OrderService.java
@@ -166,7 +166,8 @@ public class OrderService {
     public void confirmOrder(Long userId, Long orderId) {
 
         // 해당 주문이 존재하는지 + 내 주문이 맞는지 확인
-        Order order = orderRepository.findByIdAndUserId(orderId, userId)
+        // 비관적 락으로 잠가서 자동 확정 배치와 동시에 들어와도 포인트가 중복 적립되지 않게 함
+        Order order = orderRepository.findByIdAndUserIdWithPessimisticLock(orderId, userId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
 
         // 공통 주문 확정 처리
@@ -182,8 +183,12 @@ public class OrderService {
         List<Order> orders = orderRepository.findOrdersReadyForAutoConfirm(targetTime);
 
         for (Order order : orders) {
+            // 건별로 다시 락을 잡아 사용자의 수동 확정과 경합해도 한쪽만 처리되게 함
+            Order lockedOrder = orderRepository.findByIdWithPessimisticLock(order.getId())
+                    .orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
+
             // 공통 주문 확정 처리
-            confirmAndReward(order);
+            confirmAndReward(lockedOrder);
         }
     }
 
@@ -207,7 +212,8 @@ public class OrderService {
         List<OrderItem> orderItems = order.getOrderItems();
 
         for (OrderItem item : orderItems) {
-            Product product = productRepository.findById(item.getProductId())
+            // 비관적 락으로 row를 잠근 뒤 재고를 다시 확인하고 차감 (동시 주문에 대한 TOCTOU 방지)
+            Product product = productRepository.findByIdWithPessimisticLock(item.getProductId())
                     .orElseThrow(() -> new ServiceException(ErrorCode.PRODUCT_NOT_FOUND));
 
             product.removeStock(item.getQuantity());

--- a/src/main/java/com/example/paymentsystem/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/paymentsystem/domain/product/repository/ProductRepository.java
@@ -1,7 +1,17 @@
 package com.example.paymentsystem.domain.product.repository;
 
 import com.example.paymentsystem.domain.product.entity.Product;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdWithPessimisticLock(@Param("id") Long id);
 }


### PR DESCRIPTION
## Summary
- 결제 확정 시 재고 차감(`stockReduce`)이 락 없이 `findById`만 써서, 동시 결제 시 재고가 음수로 내려갈 수 있는 TOCTOU 가능성이 있었음 → `ProductRepository.findByIdWithPessimisticLock`(`PESSIMISTIC_WRITE`) 추가해 row 잠그고 재검증 후 차감
- 주문 확정(`confirmOrder`, `autoConfirmOrders`)도 락 없이 처리해 사용자 수동 확정과 자동 확정 배치가 겹치면 포인트 중복 적립 가능성이 있었음 → `OrderRepository.findByIdAndUserIdWithPessimisticLock` / `findByIdWithPessimisticLock` 추가
- 기존 Point(`UserRepository`)·Payment(`PaymentRepository`)에 적용된 `PESSIMISTIC_WRITE` 락 패턴과 동일하게 통일

## Test plan
- [x] `./gradlew compileJava` 통과 확인
- [ ] 동시 주문/동시 확정 시나리오 통합 테스트 (Testcontainers 등) 추가 검토